### PR TITLE
SB/MRH 82391326 change order of trigger

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "login",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "main": "login.js",
   "dependencies": {
     "jquery": null,

--- a/login.js
+++ b/login.js
@@ -314,7 +314,6 @@
 
       Login.prototype._generateErrors = function(error, $box, eventName) {
         var $form, messages;
-        events.trigger('event/' + eventName, error);
         this._clearErrors($box.parent());
         messages = '';
         if (error != null) {
@@ -331,7 +330,8 @@
         } else {
           messages += "An error has occured.";
         }
-        return $box.append("<ul>" + messages + "</ul>");
+        $box.append("<ul>" + messages + "</ul>");
+        return events.trigger('event/' + eventName, error);
       };
 
       Login.prototype._formatError = function(key, value) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "Login Module for Z",
   "homepage": "https://github.com/primedia/preserves",
 

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -196,7 +196,6 @@ define ['jquery', 'primedia_events', 'jquery.cookie'], ($, events) ->
       window.location.assign obj.redirectUrl if obj.redirectUrl
 
     _generateErrors: (error, $box, eventName) ->
-      events.trigger('event/' + eventName, error)
       @_clearErrors $box.parent()
       messages = ''
       if error?
@@ -209,6 +208,7 @@ define ['jquery', 'primedia_events', 'jquery.cookie'], ($, events) ->
       else
         messages += "An error has occured."
       $box.append "<ul>#{messages}</ul>"
+      events.trigger('event/' + eventName, error)
 
     _formatError: (key, value) ->
       switch key


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/82391326

For the current story, we're adding a feature-flipped Flight
component to AG that presents the zutron errors in the UI
differently. To accomplish that, we needed to move the trigger
in this script to the end of the method, so that the new
component can do its job after the normal error handling.
