### PR TITLE
SB 88542832 reload after logout

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "login",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "main": "login.js",
   "dependencies": {
     "jquery": "1.8.3",

--- a/login.js
+++ b/login.js
@@ -523,7 +523,7 @@
             return _this.expireCookie(cookie);
           };
         })(this));
-        return window.location.replace(this.my.currentUrl);
+        return window.location.reload(true);
       };
 
       Login.prototype._redirectTo = function(url) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "main": "login.js",
   "description": "Login Module for Z",
   "homepage": "https://github.com/rentpath/login.js/",

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -333,7 +333,7 @@ define ['jquery', 'primedia_events', 'jquery.cookie'], ($, events) ->
       all_cookies =  ["provider", "sgn", "zid", "z_type_email"]
       $.each all_cookies, (index, cookie) =>
         @expireCookie cookie
-      window.location.replace @my.currentUrl
+      window.location.reload(true)
 
     _redirectTo: (url) ->
       $.ajax


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/88542832

When logging out from the myplaces page, on some devices the page didn't refresh so the user still saw their saved places. 
This PR explicitly calls reload after logout. Hopefully this will resolve the issue reported by QA. It seems to work well for me (checked in Chrome, Firefox, iPhone 6 and Android Nexus).

Note: If this doesn't resolve the problem in QA, we could try using window.location.replace as before, but add a "cache busting" parameter to the url.
