### PR TITLE
[SB/WF][88512298] set cookie path to /

### DIFF
--- a/login.js
+++ b/login.js
@@ -580,7 +580,9 @@
 
       Login.prototype._setEmail = function(email) {
         this.my.zmail = email;
-        return $.cookie('zmail', email);
+        return $.cookie('zmail', email, {
+          path: '/'
+        });
       };
 
       Login.prototype._overrideDependencies = function() {

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -370,7 +370,7 @@ define ['jquery', 'primedia_events', 'jquery.cookie'], ($, events) ->
 
     _setEmail: (email) ->
       @my.zmail = email
-      $.cookie 'zmail', email
+      $.cookie 'zmail', email, { path: '/' }
 
     _overrideDependencies: ->
       @MOBILE = window.location.host.match(/(^m\.|^local\.m\.)/)?


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/88512298

Since the path option wasn't being specified, the cookie
path was defaulting to the current path such that the cookie
wasn't available site-wide.

We may want to circle back after the [refactor PR](https://github.com/rentpath/login.js/pull/10) is merged and add a spec for the cookie path. Can't run the specs now anyway.
