### PR TITLE
[men][1656318] add event delegation to logout link

### DIFF
--- a/src/login.coffee
+++ b/src/login.coffee
@@ -42,7 +42,8 @@ define [
         $.each @my.popupTypes, (index, type) =>
           @_bindForms type
 
-        $("a.logout").click (e) => @_logOut e
+        $(document).on 'click', 'a.logout', (e) =>
+          @_logOut e
 
     _prefillAccountName: ($div) ->
       $.ajax


### PR DESCRIPTION
https://www.pivotaltracker.com/epic/show/1656318

Rent's log out link is dynamically added to the page via a drop down. The current implementation in login.js won't work. Using delegation, should work for both sites.

All tests pass.
