### PR TITLE
[SB][89443342] no more "SuccessError" events

### DIFF
--- a/dist/login.js
+++ b/dist/login.js
@@ -170,7 +170,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
               events.trigger('event/emailRegistrationSuccess', data);
               return _this._redirectOnSuccess(data, $form);
             } else {
-              return new ErrorHandler(data, $form.parent().find(".errors"), 'emailRegistrationSuccessError').generateErrors();
+              return new ErrorHandler(data, $form.parent().find(".errors"), 'emailRegistrationError').generateErrors();
             }
           };
         })(this),
@@ -202,7 +202,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
               events.trigger('event/loginSuccess', data);
               return _this._redirectOnSuccess(data, $form);
             } else {
-              return new ErrorHandler(data, $form.parent().find(".errors"), 'loginSuccessError').generateErrors();
+              return new ErrorHandler(data, $form.parent().find(".errors"), 'loginError').generateErrors();
             }
           };
         })(this),
@@ -234,7 +234,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
         success: (function(_this) {
           return function(data) {
             if ((data != null) && data.errors) {
-              return new ErrorHandler(data.errors, $form.parent().find(".errors", 'changeEmailSuccessError')).generateErrors();
+              return new ErrorHandler(data.errors, $form.parent().find(".errors", 'changeEmailError')).generateErrors();
             } else {
               _this._setEmail(user_data.email);
               events.trigger('event/changeEmailSuccess', data);
@@ -266,7 +266,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
               error = {
                 'email': data.error
               };
-              return new ErrorHandler(error, $form.parent().find(".errors"), 'passwordResetSuccessError').generateErrors();
+              return new ErrorHandler(error, $form.parent().find(".errors"), 'passwordResetError').generateErrors();
             } else {
               $form.parent().empty();
               events.trigger('event/passwordResetSuccess', data);
@@ -298,7 +298,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
               error = {
                 'password': data.error
               };
-              return new ErrorHandler(error, $form.parent().find(".errors", 'passwordConfirmSuccessError')).generateErrors();
+              return new ErrorHandler(error, $form.parent().find(".errors", 'passwordConfirmError')).generateErrors();
             } else {
               $form.parent().empty();
               events.trigger('event/passwordConfirmSuccess', data);

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -10,6 +10,16 @@ define [
 ) ->
   class Login
 
+    #
+    # Note regarding Ajax response handling:
+    # IE (at least versions 8 and 9) only allows access to the response body
+    # of cross-domain requests when the response status is 200.
+    # In all use cases where we need to communicate specific errors back
+    # to the client, the server should return a 200 response that contains the
+    # error data in some identifiable way so that this code can determine which "successful"
+    # responses are in fact errors.
+    #
+
     hideIfLoggedInSelector:  '.js_hidden_if_logged_in'
     hideIfLoggedOutSelector: '.js_hidden_if_logged_out'
 
@@ -113,15 +123,15 @@ define [
           xhr.overrideMimeType "text/json"
           xhr.setRequestHeader "Accept", "application/json"
         success: (data) =>
-          if data['redirectUrl'] # IE8 XDR Fallback
+          if data['redirectUrl']
             @_stayOrLeave $form
             $("#zutron_login_form, #zutron_registration").prm_dialog_close()
             @_setSessionType()
             @_setEmail $form.find("#email").val()
             events.trigger('event/emailRegistrationSuccess', data)
             @_redirectOnSuccess data, $form
-          else
-            new ErrorHandler(data, $form.parent().find(".errors"), 'emailRegistrationSuccessError').generateErrors()
+          else # IE8 XDR Fallback
+            new ErrorHandler(data, $form.parent().find(".errors"), 'emailRegistrationError').generateErrors()
         error: (errors) =>
           new ErrorHandler($.parseJSON(errors.responseText), $form.parent().find(".errors"), 'emailRegistrationError').generateErrors()
 
@@ -135,15 +145,15 @@ define [
           xhr.overrideMimeType "text/json"
           xhr.setRequestHeader "Accept", "application/json"
         success: (data) =>
-          if data['redirectUrl'] # IE8 XDR Fallback
+          if data['redirectUrl']
             @_stayOrLeave $form
             $("#zutron_login_form, #zutron_registration").prm_dialog_close()
             @_setSessionType()
             @_setEmail $form.find("#auth_key").val()
             events.trigger('event/loginSuccess', data)
             @_redirectOnSuccess data, $form
-          else
-            new ErrorHandler(data, $form.parent().find(".errors"), 'loginSuccessError').generateErrors()
+          else # IE8 XDR Fallback
+            new ErrorHandler(data, $form.parent().find(".errors"), 'loginError').generateErrors()
         error: (errors) =>
           new ErrorHandler($.parseJSON(errors.responseText), $form.parent().find(".errors"), 'loginError').generateErrors()
 
@@ -163,7 +173,7 @@ define [
           xhr.setRequestHeader "Accept", "application/json"
         success: (data) =>
           if data? and data.errors # IE8 XDR Fallback
-            new ErrorHandler(data.errors, $form.parent().find ".errors", 'changeEmailSuccessError').generateErrors()
+            new ErrorHandler(data.errors, $form.parent().find ".errors", 'changeEmailError').generateErrors()
           else
             @_setEmail(user_data.email)
             events.trigger('event/changeEmailSuccess', data)
@@ -182,7 +192,7 @@ define [
         success: (data) =>
           if data.error # IE8 XDR Fallback
             error = {'email': data.error}
-            new ErrorHandler(error, $form.parent().find(".errors"), 'passwordResetSuccessError').generateErrors()
+            new ErrorHandler(error, $form.parent().find(".errors"), 'passwordResetError').generateErrors()
           else
             $form.parent().empty()
             events.trigger('event/passwordResetSuccess', data)
@@ -201,7 +211,7 @@ define [
         success: (data) =>
           if data? and data.error # IE8 XDR Fallback
             error = {'password': data.error}
-            new ErrorHandler(error, $form.parent().find ".errors", 'passwordConfirmSuccessError').generateErrors()
+            new ErrorHandler(error, $form.parent().find ".errors", 'passwordConfirmError').generateErrors()
           else
             $form.parent().empty()
             events.trigger('event/passwordConfirmSuccess', data)


### PR DESCRIPTION
The SuccessError stuff was really confusing and I couldn't find
anything (other than one place in AG that will be changed after this
is merged) that listened for any of those events.
Decided to remove "Success" from the event names.
Added some comments explaining why we do error handling in
the success callbacks.

My plan is to change AG after this is merged.
https://github.com/rentpath/ag/compare/sb_89443342_login_js_error_events?expand=1
Currently one error event is the "Success" flavor and the other isn't.
https://github.com/rentpath/ag/blob/dev/app/assets/javascripts/features/ui/new_signup_modal/zutron_errors.coffee#L90-L93
A [bug fix to Zutron for IE](https://github.com/rentpath/zutron/commit/43c72596a7b57a7bd134d3d1c0b937c72e519153) will respond to both login and registration errors with 200 status.

We _could_ skip this change and just change AG to listen for the "SuccessErrors", but I'm taking this as an opportunity to clean up a bit. I don't see any need to distinguish between the two flavors of error event.
