### PR TITLE
[SB/HH][89611032] use GET so IE works

### DIFF
--- a/dist/login.js
+++ b/dist/login.js
@@ -284,7 +284,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
 
     Login.prototype._submitPasswordConfirm = function($form) {
       return $.ajax({
-        type: 'POST',
+        type: 'GET',
         data: $form.serialize(),
         url: zutron_host + "/password_confirmation",
         beforeSend: function(xhr) {

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -202,7 +202,7 @@ define [
 
     _submitPasswordConfirm: ($form) ->
       $.ajax
-        type: 'POST'
+        type: 'GET' # Zutron loses params from IE POST for some reason
         data: $form.serialize()
         url: "#{zutron_host}/password_confirmation"
         beforeSend: (xhr) ->


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/89611032

Note that this PR only addresses that part of the bug story that talks about
"Password reset token is expired or invalid" showing up in IE.
The problem was that none of the parameters (password, password_confirmation
and reset_token) were showing up in the params server-side.

This simple change "solves" that problem, and in the interest of time I think it's a good enough solution.

Commit notes follow:

After spending a day and a half trying to understand this problem,
I'm going to give up and just use GET.

However I still don't understand why it's necessary to do so
since similar POST requests (such as the ones made by
_submitEmailRegistration and _submitLogin) work fine.

The problem I'm observing is that the parameters are lost or discarded
at some point server-side before the controller is called.
Again, it's very odd that the problem doesn't happen for
the SesssionsController (and possibly others).

As an experiment I even tried changing the url so that it POSTs
the password confirmation data to a simple Sinatra app (with similarly
configured rack-cors middleware), and the params were passed
into the route normally as one would expect. WTF!?
