### PR TITLE
SB 89942234 prefill email in mobile non-modal case

### DIFF
--- a/src/login.coffee
+++ b/src/login.coffee
@@ -57,7 +57,7 @@ define [
 
     _prefillAccountName: ($div) ->
       $.ajax
-        type: "GET" # POST does not work in IE
+        type: "GET"
         datatype: 'json'
         url:  "#{zutron_host}/zids/#{@my.zid}/"
         beforeSend: (xhr) ->

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -67,6 +67,12 @@ define [
           $div.find('input[name="new_first_name"]').val(data.zid.user.first_name)
           $div.find('input[name="new_last_name"]').val(data.zid.user.last_name)
 
+    _prefillEmail: ($div) ->
+      if @options.prefillEmailInput && @my.zmail
+        for selector in ['#email', '#auth_key']
+          input = $(selector)
+          input.val(@my.zmail) unless input.val()
+
     _encodeURL: (href) ->
       [path, hash] = href.split('#')
       hash = if hash then encodeURIComponent("##{hash}") else ""
@@ -277,20 +283,23 @@ define [
 
     _bindForms: (type) ->
       formID = "#zutron_#{type}_form"
-      # TODO move dependencies to bottom of page
-      if @MOBILE and $(formID).is(':visible')
-        @wireupSocialLinks $(formID)
-        @_clearInputs formID
-      $("a.#{type}, a.js_#{type}").click =>
-        $('.prm_dialog').prm_dialog_close()
-        $div = $(formID)
-        @_prefillAccountName($div) if type is 'account'
-        @_triggerModal $div
+      if @MOBILE
+        $form =  $(formID)
+        if $form.is(':visible')
+          @wireupSocialLinks $form
+          @_clearInputs formID
+          @_prefillEmail $form
+      else
+        $("a.#{type}, a.js_#{type}").click =>
+          $('.prm_dialog').prm_dialog_close()
+          $div = $(formID)
+          @_prefillAccountName($div) if type is 'account'
+          @_triggerModal $div
 
     _triggerModal: ($div) =>
       new ErrorHandler().clearErrors $div
       $div.prm_dialog_open()
-      $div.find('#email, #auth_key').val(@my.zmail) if @options.prefillEmailInput && @my.zmail
+      @_prefillEmail($div)
       $div.find(':input').filter(':visible:first').focus()
       $div.on "click", "a.close", ->
         $div.prm_dialog_close()

--- a/test/fixtures/login.html
+++ b/test/fixtures/login.html
@@ -23,3 +23,7 @@
 
 <div class="js_hidden_if_logged_in">Log In</div>
 <div class="js_hidden_if_logged_out">Log Out</div>
+
+<div id="zutron_login_form">
+  <input id="email" type="text" value="">
+</div>

--- a/test/login_spec.coffee
+++ b/test/login_spec.coffee
@@ -145,3 +145,34 @@ define [
 
         it "toggles elements when logged out", ->
           expect(login._toggleElementsWhenLoggedOut).toHaveBeenCalled()
+
+    describe "#_prefillEmail", ->
+      describe "when prefillEmailInput option true (default)", ->
+        describe "when zmail", ->
+          beforeEach ->
+            login.my.zmail = sampleEmail
+
+          describe "when input empty", ->
+            it "sets input to zmail", ->
+              login._prefillEmail($('#zutron_login_form'))
+              expect($('#email').val()).toEqual(sampleEmail)
+
+          describe "when input not empty", ->
+            it "leaves input alone", ->
+              $('#email').val('foo')
+              login._prefillEmail($('#zutron_login_form'))
+              expect($('#email').val()).toEqual('foo')
+
+        describe "when not zmail", ->
+          beforeEach ->
+            login.my.zmail = null
+          it "leaves input alone", ->
+            login._prefillEmail($('#zutron_login_form'))
+            expect($('#email').val()).toEqual('')
+
+      describe "when prefillEmailInput option false", ->
+        it "leaves input alone", ->
+          login.options.prefillEmailInput = false
+          login.my.zmail = sampleEmail
+          login._prefillEmail($('#zutron_login_form'))
+          expect($('#email').val()).toEqual('')


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/89942234

This PR fixes the email prefilling on mdot.

The prefilling was only happening inside #_triggerModal.
m.ag doesn't use modals, so the prefilling wasn't happening.

On mdot, there are separate pages for each action instead of modals.
This code was unnecessarily opening modals just before the
new page would load. (It was in fact prefilling the email field in that modal.)
