### PR TITLE
[AB][00000] pass correct arguments to error handler

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "login",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "main": [
     "dist/login.js",
     "dist/formatter.js",

--- a/dist/login.js
+++ b/dist/login.js
@@ -252,7 +252,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
         success: (function(_this) {
           return function(data) {
             if ((data != null) && data.errors) {
-              return new ErrorHandler(data.errors, $form.parent().find(".errors", 'changeEmailError')).generateErrors();
+              return new ErrorHandler(data.errors, $form.parent().find(".errors"), 'changeEmailError').generateErrors();
             } else {
               _this._setEmail(user_data.email);
               events.trigger('event/changeEmailSuccess', data);
@@ -263,7 +263,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
         })(this),
         error: (function(_this) {
           return function(errors) {
-            return new ErrorHandler($.parseJSON(errors.responseText), $form.parent().find(".errors", 'changeEmailError')).generateErrors();
+            return new ErrorHandler($.parseJSON(errors.responseText), $form.parent().find(".errors"), 'changeEmailError').generateErrors();
           };
         })(this)
       });
@@ -294,7 +294,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
         })(this),
         error: (function(_this) {
           return function(errors) {
-            return new ErrorHandler($.parseJSON(errors.responseText), $form.parent().find(".errors", 'passwordResetError')).generateErrors();
+            return new ErrorHandler($.parseJSON(errors.responseText), $form.parent().find(".errors"), 'passwordResetError').generateErrors();
           };
         })(this)
       });
@@ -316,7 +316,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
               error = {
                 'password': data.error
               };
-              return new ErrorHandler(error, $form.parent().find(".errors", 'passwordConfirmError')).generateErrors();
+              return new ErrorHandler(error, $form.parent().find(".errors"), 'passwordConfirmError').generateErrors();
             } else {
               $form.parent().empty();
               events.trigger('event/passwordConfirmSuccess', data);
@@ -327,7 +327,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
         })(this),
         error: (function(_this) {
           return function(errors) {
-            return new ErrorHandler($.parseJSON(errors.responseText), $form.parent().find(".errors", 'passwordConfirmError')).generateErrors();
+            return new ErrorHandler($.parseJSON(errors.responseText), $form.parent().find(".errors"), 'passwordConfirmError').generateErrors();
           };
         })(this)
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "description": "Login Module for Z",
   "homepage": "https://github.com/rentpath/login.js/",
   "author": {

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -179,14 +179,14 @@ define [
           xhr.setRequestHeader "Accept", "application/json"
         success: (data) =>
           if data? and data.errors # IE8 XDR Fallback
-            new ErrorHandler(data.errors, $form.parent().find ".errors", 'changeEmailError').generateErrors()
+            new ErrorHandler(data.errors, $form.parent().find(".errors"), 'changeEmailError').generateErrors()
           else
             @_setEmail(user_data.email)
             events.trigger('event/changeEmailSuccess', data)
             $('#zutron_account_form').prm_dialog_close()
             @_triggerModal $("#zutron_success_form")
         error: (errors) =>
-          new ErrorHandler($.parseJSON(errors.responseText), $form.parent().find ".errors", 'changeEmailError').generateErrors()
+          new ErrorHandler($.parseJSON(errors.responseText), $form.parent().find(".errors"), 'changeEmailError').generateErrors()
 
     _submitPasswordReset: ($form) ->
       $.ajax
@@ -204,7 +204,7 @@ define [
             events.trigger('event/passwordResetSuccess', data)
             $('.reset_success').html(data.success).show()
         error: (errors) =>
-          new ErrorHandler($.parseJSON(errors.responseText), $form.parent().find ".errors", 'passwordResetError').generateErrors()
+          new ErrorHandler($.parseJSON(errors.responseText), $form.parent().find(".errors"), 'passwordResetError').generateErrors()
 
     _submitPasswordConfirm: ($form) ->
       $.ajax
@@ -217,14 +217,14 @@ define [
         success: (data) =>
           if data? and data.error # IE8 XDR Fallback
             error = {'password': data.error}
-            new ErrorHandler(error, $form.parent().find ".errors", 'passwordConfirmError').generateErrors()
+            new ErrorHandler(error, $form.parent().find(".errors"), 'passwordConfirmError').generateErrors()
           else
             $form.parent().empty()
             events.trigger('event/passwordConfirmSuccess', data)
             $('.reset_success').html(data.success).show()
             @_determineClient()
         error: (errors) =>
-          new ErrorHandler($.parseJSON(errors.responseText), $form.parent().find ".errors", 'passwordConfirmError').generateErrors()
+          new ErrorHandler($.parseJSON(errors.responseText), $form.parent().find(".errors"), 'passwordConfirmError').generateErrors()
 
     _clearInputs: (formID) ->
       $inputs = $(formID + ' input[type="email"]').add $(formID + ' input[type="password"]')


### PR DESCRIPTION
There were a few places where new instances of the `ErrorHandler` class were meant to be passed event names as the last argument, but weren't due to some missing parenthesis.  This adds them in.

Specs pass.
