### PR TITLE
[AB][91998706] decouple form submissions from UI

### DIFF
--- a/dist/login.js
+++ b/dist/login.js
@@ -176,10 +176,12 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
     };
 
     Login.prototype.resetUserPassword = function(data, successCallback, errorCallback) {
+      if (typeof data === 'object') {
+        data = $.param(data);
+      }
       return $.ajax({
         type: 'POST',
-        data: data,
-        url: zutron_host + "/password_reset",
+        url: zutron_host + "/password_reset?" + data,
         beforeSend: function(xhr) {
           xhr.overrideMimeType("text/json");
           return xhr.setRequestHeader("Accept", "application/json");

--- a/dist/login.js
+++ b/dist/login.js
@@ -310,25 +310,33 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
         email: $('input[name="new_email"]').val(),
         email_confirmation: $('input[name="new_email_confirm"]').val()
       };
-      onSuccess = function() {
-        $('#zutron_account_form').prm_dialog_close();
-        return this._triggerModal($("#zutron_success_form"));
-      };
-      onError = function(errors) {
-        return new ErrorHandler(errors, $form.parent().find(".errors"), 'changeEmailError').generateErrors();
-      };
+      onSuccess = (function(_this) {
+        return function() {
+          $('#zutron_account_form').prm_dialog_close();
+          return _this._triggerModal($("#zutron_success_form"));
+        };
+      })(this);
+      onError = (function(_this) {
+        return function(errors) {
+          return new ErrorHandler(errors, $form.parent().find(".errors"), 'changeEmailError').generateErrors();
+        };
+      })(this);
       return this.saveUserData(user_data, onSuccess, onError);
     };
 
     Login.prototype._submitPasswordReset = function($form) {
       var onError, onSuccess;
-      onSuccess = function(data) {
-        $form.parent().empty();
-        return $('.reset_success').html(data.success).show();
-      };
-      onError = function(errors) {
-        return new ErrorHandler(errors, $form.parent().find(".errors"), 'passwordResetError').generateErrors();
-      };
+      onSuccess = (function(_this) {
+        return function(data) {
+          $form.parent().empty();
+          return $('.reset_success').html(data.success).show();
+        };
+      })(this);
+      onError = (function(_this) {
+        return function(errors) {
+          return new ErrorHandler(errors, $form.parent().find(".errors"), 'passwordResetError').generateErrors();
+        };
+      })(this);
       return this.resetUserPassword($form.serialize(), onSuccess, onError);
     };
 

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -205,18 +205,18 @@ define [
         last_name: $('input[name="new_last_name"]').val()
         email: $('input[name="new_email"]').val()
         email_confirmation: $('input[name="new_email_confirm"]').val()
-      onSuccess = ->
+      onSuccess = =>
         $('#zutron_account_form').prm_dialog_close()
         @_triggerModal $("#zutron_success_form")
-      onError = (errors) ->
+      onError = (errors) =>
         new ErrorHandler(errors, $form.parent().find(".errors"), 'changeEmailError').generateErrors()
       @saveUserData(user_data, onSuccess, onError)
 
     _submitPasswordReset: ($form) ->
-      onSuccess = (data) ->
+      onSuccess = (data) =>
         $form.parent().empty()
         $('.reset_success').html(data.success).show()
-      onError = (errors)->
+      onError = (errors) =>
         new ErrorHandler(errors, $form.parent().find(".errors"), 'passwordResetError').generateErrors()
       @resetUserPassword($form.serialize(), onSuccess, onError)
 

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -127,10 +127,10 @@ define [
           errorCallback($.parseJSON(errors.responseText)) if errorCallback
 
     resetUserPassword: (data, successCallback, errorCallback) ->
+      data = $.param(data) if typeof data is 'object'
       $.ajax
         type: 'POST'
-        data: data
-        url: "#{zutron_host}/password_reset"
+        url: zutron_host + "/password_reset?" + data,
         beforeSend: (xhr) ->
           xhr.overrideMimeType "text/json"
           xhr.setRequestHeader "Accept", "application/json"

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -107,6 +107,42 @@ define [
         @_triggerModal element if $.cookie("user_type") is "new"
         @expireCookie "user_type"
 
+    saveUserData: (data, successCallback, errorCallback) ->
+      $.ajax
+        type: "GET" # POST does not work in IE
+        data: data
+        datatype: 'json'
+        url:  "#{zutron_host}/zids/#{@my.zid}/email_change.json"
+        beforeSend: (xhr) ->
+          xhr.overrideMimeType "text/json"
+          xhr.setRequestHeader "Accept", "application/json"
+        success: (response) =>
+          if response? and response.errors # IE8 XDR Fallback
+            errorCallback(response.errors) if errorCallback
+          else
+            @_setEmail(data.email)
+            events.trigger('event/changeEmailSuccess', response)
+            successCallback(response) if successCallback
+        error: (errors) =>
+          errorCallback($.parseJSON(errors.responseText)) if errorCallback
+
+    resetUserPassword: (data, successCallback, errorCallback) ->
+      $.ajax
+        type: 'POST'
+        data: data
+        url: "#{zutron_host}/password_reset"
+        beforeSend: (xhr) ->
+          xhr.overrideMimeType "text/json"
+          xhr.setRequestHeader "Accept", "application/json"
+        success: (response) =>
+          if response? and response.errors # IE8 XDR Fallback
+            errorCallback(response.errors) if errorCallback
+          else
+            events.trigger('event/passwordResetSuccess', data)
+            successCallback(response) if successCallback
+        error: (errors) =>
+          errorCallback($.parseJSON(errors.responseText)) if errorCallback
+
     _enableLoginRegistration: =>
       $('#zutron_register_form form').submit (e) =>
         @_submitEmailRegistration $(e.target)
@@ -169,42 +205,20 @@ define [
         last_name: $('input[name="new_last_name"]').val()
         email: $('input[name="new_email"]').val()
         email_confirmation: $('input[name="new_email_confirm"]').val()
-      $.ajax
-        type: "GET" # POST does not work in IE
-        data: user_data
-        datatype: 'json'
-        url:  "#{zutron_host}/zids/#{@my.zid}/email_change.json"
-        beforeSend: (xhr) ->
-          xhr.overrideMimeType "text/json"
-          xhr.setRequestHeader "Accept", "application/json"
-        success: (data) =>
-          if data? and data.errors # IE8 XDR Fallback
-            new ErrorHandler(data.errors, $form.parent().find(".errors"), 'changeEmailError').generateErrors()
-          else
-            @_setEmail(user_data.email)
-            events.trigger('event/changeEmailSuccess', data)
-            $('#zutron_account_form').prm_dialog_close()
-            @_triggerModal $("#zutron_success_form")
-        error: (errors) =>
-          new ErrorHandler($.parseJSON(errors.responseText), $form.parent().find(".errors"), 'changeEmailError').generateErrors()
+      onSuccess = ->
+        $('#zutron_account_form').prm_dialog_close()
+        @_triggerModal $("#zutron_success_form")
+      onError = (errors) ->
+        new ErrorHandler(errors, $form.parent().find(".errors"), 'changeEmailError').generateErrors()
+      @saveUserData(user_data, onSuccess, onError)
 
     _submitPasswordReset: ($form) ->
-      $.ajax
-        type: 'POST'
-        url: "#{zutron_host}/password_reset?#{$form.serialize()}"
-        beforeSend: (xhr) ->
-          xhr.overrideMimeType "text/json"
-          xhr.setRequestHeader "Accept", "application/json"
-        success: (data) =>
-          if data.error # IE8 XDR Fallback
-            error = {'email': data.error}
-            new ErrorHandler(error, $form.parent().find(".errors"), 'passwordResetError').generateErrors()
-          else
-            $form.parent().empty()
-            events.trigger('event/passwordResetSuccess', data)
-            $('.reset_success').html(data.success).show()
-        error: (errors) =>
-          new ErrorHandler($.parseJSON(errors.responseText), $form.parent().find(".errors"), 'passwordResetError').generateErrors()
+      onSuccess = (data) ->
+        $form.parent().empty()
+        $('.reset_success').html(data.success).show()
+      onError = (errors)->
+        new ErrorHandler(errors, $form.parent().find(".errors"), 'passwordResetError').generateErrors()
+      @resetUserPassword($form.serialize(), onSuccess, onError)
 
     _submitPasswordConfirm: ($form) ->
       $.ajax
@@ -374,5 +388,7 @@ define [
   init: (options = {}) -> @instance = new Login(options)
   wireupSocialLinks: -> @instance.wireupSocialLinks()
   toggleRegistrationDiv: (div) -> @instance.toggleRegistrationDiv(div)
+  saveUserData: -> @instance.saveUserData.apply(@instance, arguments)
+  resetUserPassword: -> @instance.resetUserPassword.apply(@instance, arguments)
   expireCookie: -> @instance.expireCookie()
   session: -> @instance.my.session


### PR DESCRIPTION
**Login.js** is currently highly coupled to the UI experience on AG (and presumably Rentals), and in some aspects not conducive to implementing the Rent UI experience.

This PR modifies the  `_submitChangeUserData` and `_submitPasswordReset` methods by moving their AJAX logic to separate, publicly exposed methods, that accept success/error callbacks. In effect, this module retains its responsibility to handle the relevant API requests, while allowing delegation of UI behavior.

I recognize that this in some ways breaks the structural convention of the module, so I'm all ears if anyone has suggestions for alternate approaches.

The [story](https://www.pivotaltracker.com/story/show/91998706) outlines a few UI differences between Rent and AG relevant to this PR.
