### PR TITLE
[AB][87955530] fix modal bindings

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "login",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "main": [
     "dist/login.js",
     "dist/formatter.js",

--- a/dist/login.js
+++ b/dist/login.js
@@ -417,25 +417,26 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
     Login.prototype._bindForms = function(type) {
       var $form, formID;
       formID = "#zutron_" + type + "_form";
+      $form = $(formID);
       if (this.MOBILE) {
-        $form = $(formID);
         if ($form.is(':visible')) {
           this.wireupSocialLinks($form);
           this._clearInputs(formID);
           return this._prefillEmail($form);
         }
       } else {
-        return $("a." + type + ", a.js_" + type).click((function(_this) {
+        $("a." + type + ", a.js_" + type).click((function(_this) {
           return function() {
-            var $div;
-            $('.prm_dialog').prm_dialog_close();
-            $div = $(formID);
+            $('.prm_dialog:visible').prm_dialog_close();
             if (type === 'account') {
-              _this._prefillAccountName($div);
+              _this._prefillAccountName($form);
             }
-            return _this._triggerModal($div);
+            return _this._triggerModal($form);
           };
         })(this));
+        return $form.on("click", "a.close", function() {
+          return $form.prm_dialog_close();
+        });
       }
     };
 
@@ -444,9 +445,6 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
       $div.prm_dialog_open();
       this._prefillEmail($div);
       $div.find(':input').filter(':visible:first').focus();
-      $div.on("click", "a.close", function() {
-        return $div.prm_dialog_close();
-      });
       return this.wireupSocialLinks($div);
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "description": "Login Module for Z",
   "homepage": "https://github.com/rentpath/login.js/",
   "author": {

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -283,26 +283,25 @@ define [
 
     _bindForms: (type) ->
       formID = "#zutron_#{type}_form"
+      $form  = $(formID)
       if @MOBILE
-        $form =  $(formID)
         if $form.is(':visible')
           @wireupSocialLinks $form
           @_clearInputs formID
           @_prefillEmail $form
       else
         $("a.#{type}, a.js_#{type}").click =>
-          $('.prm_dialog').prm_dialog_close()
-          $div = $(formID)
-          @_prefillAccountName($div) if type is 'account'
-          @_triggerModal $div
+          $('.prm_dialog:visible').prm_dialog_close()
+          @_prefillAccountName($form) if type is 'account'
+          @_triggerModal $form
+        $form.on "click", "a.close", ->
+          $form.prm_dialog_close()
 
     _triggerModal: ($div) =>
       new ErrorHandler().clearErrors $div
       $div.prm_dialog_open()
       @_prefillEmail($div)
       $div.find(':input').filter(':visible:first').focus()
-      $div.on "click", "a.close", ->
-        $div.prm_dialog_close()
       @wireupSocialLinks $div
 
     _bindSocialLink: ($link, url, $div) ->


### PR DESCRIPTION
This PR fixes two pain-points for anyone attempting to work with the `dialogClosed` event that gets fired after closing any of the modals handled by this repo.
- Every time a modal is opened, any element with `.prm_dialog` class gets closed, meaning a close event gets fired for the modal that is about to be opened.
- Every time a modal is opened, a callback is bound to the click event of elements with class of `.close`, resulting in an equal number of bound callbacks to the amount of times the modal has been opened.

To illustrate, the following is the result of me opening and closing the login modal on AG 6 times.

![screen shot 2015-04-09 at 9 17 52 am](https://cloud.githubusercontent.com/assets/10748727/7071355/8fe66548-de99-11e4-912e-fb013ac8887b.png)

[relevant story](https://www.pivotaltracker.com/story/show/87955530)
