### PR TITLE
SB 91093836 method cleanup

### DIFF
--- a/dist/login.js
+++ b/dist/login.js
@@ -142,7 +142,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
 
     Login.prototype.saveUserData = function(data, successCallback, errorCallback) {
       return $.ajax({
-        type: "GET",
+        type: "POST",
         data: data,
         datatype: 'json',
         url: zutron_host + "/zids/" + this.my.zid + "/email_change.json",
@@ -342,7 +342,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
 
     Login.prototype._submitPasswordConfirm = function($form) {
       return $.ajax({
-        type: 'GET',
+        type: 'POST',
         data: $form.serialize(),
         url: zutron_host + "/password_confirmation",
         beforeSend: function(xhr) {

--- a/dist/login.js
+++ b/dist/login.js
@@ -525,7 +525,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
 
     Login.prototype._redirectTo = function(url) {
       return $.ajax({
-        type: "get",
+        type: "GET",
         url: zutron_host + "/ops/heartbeat/riak",
         success: function() {
           return window.location.assign(url);

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -342,7 +342,7 @@ define [
 
     _redirectTo: (url) ->
       $.ajax
-        type: "get"
+        type: "GET"
         url: zutron_host + "/ops/heartbeat/riak"
         success: ->
           window.location.assign url

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -109,7 +109,7 @@ define [
 
     saveUserData: (data, successCallback, errorCallback) ->
       $.ajax
-        type: "GET" # POST does not work in IE
+        type: "POST"
         data: data
         datatype: 'json'
         url:  "#{zutron_host}/zids/#{@my.zid}/email_change.json"
@@ -222,7 +222,7 @@ define [
 
     _submitPasswordConfirm: ($form) ->
       $.ajax
-        type: 'GET' # Zutron loses params from IE POST for some reason
+        type: 'POST'
         data: $form.serialize()
         url: "#{zutron_host}/password_confirmation"
         beforeSend: (xhr) ->


### PR DESCRIPTION
[Chore](https://www.pivotaltracker.com/story/show/91093836)

Now that we have a [server-side shim for bad POSTs from IE](https://github.com/rentpath/zutron/commit/0afab8caf565adae8a936961baafcba2d7159113), we can use POST where appropriate.
