### PR TITLE
[EL/TB] [92937716] remove /riak from zutron heartbeat

### DIFF
--- a/dist/login.js
+++ b/dist/login.js
@@ -526,7 +526,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
     Login.prototype._redirectTo = function(url) {
       return $.ajax({
         type: "GET",
-        url: zutron_host + "/ops/heartbeat/riak",
+        url: zutron_host + "/ops/heartbeat",
         success: function() {
           return window.location.assign(url);
         },

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -343,7 +343,7 @@ define [
     _redirectTo: (url) ->
       $.ajax
         type: "GET"
-        url: zutron_host + "/ops/heartbeat/riak"
+        url: zutron_host + "/ops/heartbeat"
         success: ->
           window.location.assign url
         error: =>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/92937716

Riak was removed from Zutron, so this call no longer succeeds.

`npm test` tests all pass
