### PR TITLE
 [AB][93361328] bind new zid callback immediately

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "login",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "main": [
     "dist/login.js",
     "dist/formatter.js",

--- a/dist/login.js
+++ b/dist/login.js
@@ -34,11 +34,13 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
         currentUrl: window.location.href,
         popupTypes: ["login", "register", "account", "reset", "confirm", "success"]
       };
+      $(document).on('new_zid_obtained', (function(_this) {
+        return function() {
+          return _this.my.zid = $.cookie('zid');
+        };
+      })(this));
       $(document).ready((function(_this) {
         return function() {
-          $('body').bind('new_zid_obtained', function() {
-            return _this.my.zid = $.cookie('zid');
-          });
           _this._welcomeMessage();
           _this._toggleSessionState();
           _this._enableLoginRegistration();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "description": "Login Module for Z",
   "homepage": "https://github.com/rentpath/login.js/",
   "author": {

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -41,10 +41,10 @@ define [
         currentUrl: window.location.href
         popupTypes: ["login", "register", "account", "reset", "confirm", "success"]
 
-      $(document).ready =>
-        $('body').bind 'new_zid_obtained', =>
-          @my.zid = $.cookie 'zid'
+      $(document).on 'new_zid_obtained', =>
+        @my.zid = $.cookie 'zid'
 
+      $(document).ready =>
         @_welcomeMessage()
         @_toggleSessionState()
         @_enableLoginRegistration()


### PR DESCRIPTION
Zutron does not wait for document ready to trigger the `new_zid_obtained` event, and it has no reason to.  However, since _login.js_ does wait for document ready to bind it's listener to that event, a race condition exists that sometimes results in the _login.js_ event handler never being called.

https://www.pivotaltracker.com/story/show/93361328
