### PR TITLE
[LT][93719994] Trigger 'emailRegistrationSuccess' on document

### DIFF
--- a/dist/login.js
+++ b/dist/login.js
@@ -258,6 +258,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
               _this._setSessionType();
               _this._setEmail($form.find("#email").val());
               events.trigger('event/emailRegistrationSuccess', data);
+              $(document).trigger('emailRegistrationSuccess', data);
               return _this._redirectOnSuccess(data, $form);
             } else {
               return new ErrorHandler(data, $form.parent().find(".errors"), 'emailRegistrationError').generateErrors();

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -171,6 +171,7 @@ define [
             @_setSessionType()
             @_setEmail $form.find("#email").val()
             events.trigger('event/emailRegistrationSuccess', data)
+            $(document).trigger('emailRegistrationSuccess', data)
             @_redirectOnSuccess data, $form
           else # IE8 XDR Fallback
             new ErrorHandler(data, $form.parent().find(".errors"), 'emailRegistrationError').generateErrors()


### PR DESCRIPTION
[Pivotal Story](https://www.pivotaltracker.com/story/show/93719994)

This change makes it easy for Rent to know when a user
has been registered. The event is used to send an account
registration email that contains first name, last name, email
address, and newsletter preferences.
