### PR TITLE
[AB][93583528] add realm to social login link

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "login",
-  "version": "0.2.38",
+  "version": "0.2.39",
   "main": [
     "dist/login.js",
     "dist/formatter.js",

--- a/dist/login.js
+++ b/dist/login.js
@@ -14,18 +14,10 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
     };
 
     function Login(options) {
-      var key, value;
-      if (options == null) {
-        options = {};
-      }
       this._triggerModal = bind(this._triggerModal, this);
       this._submitEmailRegistration = bind(this._submitEmailRegistration, this);
       this._enableLoginRegistration = bind(this._enableLoginRegistration, this);
-      this.options = {};
-      for (key in DEFAULT_OPTIONS) {
-        value = DEFAULT_OPTIONS[key];
-        this.options[key] = options[key] != null ? options[key] : value;
-      }
+      this.options = $.extend({}, DEFAULT_OPTIONS, options);
       this._overrideDependencies();
       this.my = {
         zmail: $.cookie('zmail'),
@@ -122,7 +114,11 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
 
     Login.prototype.wireupSocialLinks = function($div) {
       var baseUrl, fbLink, googleLink, twitterLink;
-      baseUrl = zutron_host + "?zid_id=" + this.my.zid + "&referrer=" + (encodeURIComponent(this.my.currentUrl)) + "&technique=";
+      baseUrl = zutron_host + "?zid_id=" + this.my.zid + "&referrer=" + (encodeURIComponent(this.my.currentUrl));
+      if (this.options.realm) {
+        baseUrl += "&realm=" + this.options.realm;
+      }
+      baseUrl += '&technique=';
       fbLink = $div.find("a.icon_facebook48");
       twitterLink = $div.find("a.icon_twitter48");
       googleLink = $div.find("a.icon_google_plus48");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login",
-  "version": "0.2.38",
+  "version": "0.2.39",
   "description": "Login Module for Z",
   "homepage": "https://github.com/rentpath/login.js/",
   "author": {

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -27,11 +27,8 @@ define [
       prefillEmailInput: true
     }
 
-    constructor: (options = {}) ->
-      @options = {}
-      for key, value of DEFAULT_OPTIONS
-        @options[key] = if options[key]? then options[key] else value
-
+    constructor: (options) ->
+      @options = $.extend({}, DEFAULT_OPTIONS, options)
       @_overrideDependencies()
 
       @my =
@@ -93,7 +90,9 @@ define [
         $.cookie cookie, "", options
 
     wireupSocialLinks: ($div) ->
-      baseUrl = "#{zutron_host}?zid_id=#{@my.zid}&referrer=#{encodeURIComponent(@my.currentUrl)}&technique="
+      baseUrl = "#{zutron_host}?zid_id=#{@my.zid}&referrer=#{encodeURIComponent(@my.currentUrl)}"
+      baseUrl += "&realm=#{@options.realm}" if @options.realm
+      baseUrl += '&technique='
       fbLink = $div.find("a.icon_facebook48")
       twitterLink = $div.find("a.icon_twitter48")
       googleLink = $div.find("a.icon_google_plus48")


### PR DESCRIPTION
This allows options to be correctly passed into `Login.init`, and optionally adds a `realm` query argument when constructing base social URL's.

https://www.pivotaltracker.com/story/show/93583528
