### PR TITLE
[AB][96215026] use events to trigger opening of dialogs

### DIFF
--- a/dist/login.js
+++ b/dist/login.js
@@ -476,11 +476,11 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
             return _this._triggerModal($form);
           };
         })(this));
-        $("a." + type + ", a.js_" + type).click((function(_this) {
-          return function() {
-            return $(document).trigger(showEvent);
-          };
-        })(this));
+        $("a." + type + ", a.js_" + type).click(function() {
+          return $(document).trigger($.Event(showEvent, {
+            relatedTarget: this
+          }));
+        });
         return $form.on("click", "a.close", function() {
           return $form.prm_dialog_close();
         });

--- a/dist/login.js
+++ b/dist/login.js
@@ -10,7 +10,8 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
     Login.prototype.hideIfLoggedOutSelector = '.js_hidden_if_logged_out';
 
     DEFAULT_OPTIONS = {
-      prefillEmailInput: true
+      prefillEmailInput: true,
+      showDialogEventTemplate: 'uiShow{type}Dialog'
     };
 
     function Login(options) {
@@ -454,7 +455,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
     };
 
     Login.prototype._bindForms = function(type) {
-      var $form, formID;
+      var $form, eventType, formID, showEvent;
       formID = "#zutron_" + type + "_form";
       $form = $(formID);
       if (this.MOBILE) {
@@ -464,13 +465,20 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
           return this._prefillEmail($form);
         }
       } else {
-        $("a." + type + ", a.js_" + type).click((function(_this) {
+        eventType = type.charAt(0).toUpperCase() + type.slice(1);
+        showEvent = this.options.showDialogEventTemplate.replace('{type}', eventType);
+        $(document).on(showEvent, (function(_this) {
           return function() {
             $('.prm_dialog:visible').prm_dialog_close();
             if (type === 'account') {
               _this._prefillAccountName($form);
             }
             return _this._triggerModal($form);
+          };
+        })(this));
+        $("a." + type + ", a.js_" + type).click((function(_this) {
+          return function() {
+            return $(document).trigger(showEvent);
           };
         })(this));
         return $form.on("click", "a.close", function() {

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -311,8 +311,8 @@ define [
           $('.prm_dialog:visible').prm_dialog_close()
           @_prefillAccountName($form) if type is 'account'
           @_triggerModal $form
-        $("a.#{type}, a.js_#{type}").click =>
-          $(document).trigger showEvent
+        $("a.#{type}, a.js_#{type}").click ->
+          $(document).trigger $.Event(showEvent, relatedTarget: @)
         $form.on "click", "a.close", ->
           $form.prm_dialog_close()
 

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -25,6 +25,7 @@ define [
 
     DEFAULT_OPTIONS = {
       prefillEmailInput: true
+      showDialogEventTemplate: 'uiShow{type}Dialog'
     }
 
     constructor: (options) ->
@@ -304,10 +305,14 @@ define [
           @_clearInputs formID
           @_prefillEmail $form
       else
-        $("a.#{type}, a.js_#{type}").click =>
+        eventType = type.charAt(0).toUpperCase() + type.slice(1)
+        showEvent = @options.showDialogEventTemplate.replace('{type}', eventType)
+        $(document).on showEvent, =>
           $('.prm_dialog:visible').prm_dialog_close()
           @_prefillAccountName($form) if type is 'account'
           @_triggerModal $form
+        $("a.#{type}, a.js_#{type}").click =>
+          $(document).trigger showEvent
         $form.on "click", "a.close", ->
           $form.prm_dialog_close()
 


### PR DESCRIPTION
Dialogs currently have to be opened via a _click_ on a link element, else they not receive the proper opening treatment (pre-filling inputs etc..).

This can be problematic in several ways, most notably that manually opening a dialog requires _triggering_ a click event on an unknown link element, which may or may not be present in the markup.

This PR modifies how dialogs are opened by having the document listen for events requesting that a specific dialog be opened.  Clicking on the previously used link elements triggers the corresponding event name.

https://www.pivotaltracker.com/story/show/96215026
