### PR TITLE
[WF][101935758] Enable close buttons on welcome message

### DIFF
--- a/dist/login.js
+++ b/dist/login.js
@@ -136,8 +136,11 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
         if ($.cookie("user_type") === "new") {
           this._triggerModal(element);
         }
-        return this.expireCookie("user_type");
+        this.expireCookie("user_type");
       }
+      return $('a.close').on("click", function() {
+        return element.prm_dialog_close();
+      });
     };
 
     Login.prototype.saveUserData = function(data, successCallback, errorCallback) {

--- a/dist/login.js
+++ b/dist/login.js
@@ -137,10 +137,10 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
           this._triggerModal(element);
         }
         this.expireCookie("user_type");
+        return $('a.close').on("click", function() {
+          return element.prm_dialog_close();
+        });
       }
-      return $('a.close').on("click", function() {
-        return element.prm_dialog_close();
-      });
     };
 
     Login.prototype.saveUserData = function(data, successCallback, errorCallback) {

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -107,6 +107,8 @@ define [
       if element.length > 0
         @_triggerModal element if $.cookie("user_type") is "new"
         @expireCookie "user_type"
+      $('a.close').on "click", ->
+        element.prm_dialog_close()
 
     saveUserData: (data, successCallback, errorCallback) ->
       $.ajax

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -107,8 +107,8 @@ define [
       if element.length > 0
         @_triggerModal element if $.cookie("user_type") is "new"
         @expireCookie "user_type"
-      $('a.close').on "click", ->
-        element.prm_dialog_close()
+        $('a.close').on "click", ->
+          element.prm_dialog_close()
 
     saveUserData: (data, successCallback, errorCallback) ->
       $.ajax


### PR DESCRIPTION
# [Close and "X" buttons don't work when registering a new user](https://www.pivotaltracker.com/story/show/101935758)
- Enables both close and `X` button image in the welcome message displayed after registering as new user
- Will need to cut a new tag to include in AG's bower.json once this PR is merged
