### PR TITLE
[TW][120332829] Remove setRedirectUrl and add setRedirectOnLogin

### DIFF
--- a/dist/login.js
+++ b/dist/login.js
@@ -12,8 +12,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
     DEFAULT_OPTIONS = {
       prefillEmailInput: true,
       showDialogEventTemplate: 'uiShow{type}Dialog',
-      redirectOnLogin: true,
-      redirectUrl: null
+      redirectOnLogin: true
     };
 
     function Login(options) {
@@ -116,9 +115,8 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
     };
 
     Login.prototype.wireupSocialLinks = function($div) {
-      var baseUrl, fbLink, googleLink, referrer, twitterLink;
-      referrer = this.options.redirectUrl || this.my.currentUrl;
-      baseUrl = zutron_host + "?zid_id=" + this.my.zid + "&referrer=" + (encodeURIComponent(referrer));
+      var baseUrl, fbLink, googleLink, twitterLink;
+      baseUrl = zutron_host + "?zid_id=" + this.my.zid + "&referrer=" + (encodeURIComponent(this.my.currentUrl));
       if (this.options.realm) {
         baseUrl += "&realm=" + this.options.realm;
       }
@@ -215,8 +213,8 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
       });
     };
 
-    Login.prototype.setRedirectUrl = function(url) {
-      return this.options.redirectUrl = url;
+    Login.prototype.setRedirectOnLogin = function(value) {
+      return this.options.redirectOnLogin = value;
     };
 
     Login.prototype._enableLoginRegistration = function() {
@@ -411,11 +409,9 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
     };
 
     Login.prototype._redirectOnSuccess = function(obj, $form) {
-      var url;
       $form.prm_dialog_close();
-      url = this.options.redirectUrl || obj.redirectUrl;
-      if (url) {
-        return window.location.assign(url);
+      if (obj.redirectUrl) {
+        return window.location.assign(obj.redirectUrl);
       }
     };
 
@@ -647,8 +643,8 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
     session: function() {
       return this.instance.my.session;
     },
-    setRedirectUrl: function(url) {
-      return this.instance.setRedirectUrl(url);
+    setRedirectOnLogin: function(value) {
+      return this.instance.setRedirectOnLogin(value);
     }
   };
 });

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -27,7 +27,6 @@ define [
       prefillEmailInput: true
       showDialogEventTemplate: 'uiShow{type}Dialog'
       redirectOnLogin: true
-      redirectUrl: null
     }
 
     constructor: (options) ->
@@ -93,8 +92,7 @@ define [
         $.cookie cookie, "", options
 
     wireupSocialLinks: ($div) ->
-      referrer = @options.redirectUrl || @my.currentUrl
-      baseUrl = "#{zutron_host}?zid_id=#{@my.zid}&referrer=#{encodeURIComponent(referrer)}"
+      baseUrl = "#{zutron_host}?zid_id=#{@my.zid}&referrer=#{encodeURIComponent(@my.currentUrl)}"
       baseUrl += "&realm=#{@options.realm}" if @options.realm
       baseUrl += '&technique='
       fbLink = $div.find("a.icon_facebook48")
@@ -148,8 +146,8 @@ define [
         error: (errors) =>
           errorCallback($.parseJSON(errors.responseText).errors) if errorCallback
 
-    setRedirectUrl: (url) ->
-      @options.redirectUrl = url
+    setRedirectOnLogin: (value) ->
+      @options.redirectOnLogin = value
 
     _enableLoginRegistration: =>
       $('#zutron_register_form form').submit (e) =>
@@ -263,8 +261,7 @@ define [
 
     _redirectOnSuccess: (obj, $form) ->
       $form.prm_dialog_close()
-      url = @options.redirectUrl || obj.redirectUrl
-      window.location.assign url if url
+      window.location.assign obj.redirectUrl if obj.redirectUrl
 
     _toggleSessionState: ->
       if @my.session
@@ -406,4 +403,4 @@ define [
   resetUserPassword: -> @instance.resetUserPassword.apply(@instance, arguments)
   expireCookie: -> @instance.expireCookie()
   session: -> @instance.my.session
-  setRedirectUrl: (url) -> @instance.setRedirectUrl(url)
+  setRedirectOnLogin: (value) -> @instance.setRedirectOnLogin(value)


### PR DESCRIPTION
https://www.pivotaltracker.com/projects/1054856/stories/120332829

The `setRedirectUrl` function will not work correctly, as it bypasses the `/login/` route (which sets Zutron cookies).  Instead, `setRedirectOnLogin` should be used to turn off redirecting.  The app (in this case, AG) will then capture the registration or login success event and set the cookies as needed, before doing the redirect, itself.
