### PR TITLE
[TW][120028041] Allow social logins to redirect to other URL

### DIFF
--- a/dist/login.js
+++ b/dist/login.js
@@ -116,9 +116,8 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
     };
 
     Login.prototype.wireupSocialLinks = function($div) {
-      var baseUrl, fbLink, googleLink, twitterLink, url;
-      url = this.options.referrerUrl || this.my.currentUrl;
-      baseUrl = zutron_host + "?zid_id=" + this.my.zid + "&referrer=" + (encodeURIComponent(url));
+      var baseUrl, fbLink, googleLink, twitterLink;
+      baseUrl = zutron_host + "?zid_id=" + this.my.zid + "&referrer=" + (encodeURIComponent(this.getReferrerUrl()));
       if (this.options.realm) {
         baseUrl += "&realm=" + this.options.realm;
       }
@@ -221,6 +220,10 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
 
     Login.prototype.setReferrerUrl = function(url) {
       return this.options.referrerUrl = url;
+    };
+
+    Login.prototype.getReferrerUrl = function() {
+      return this.options.referrerUrl || this.my.currentUrl;
     };
 
     Login.prototype._enableLoginRegistration = function() {
@@ -572,7 +575,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
 
     Login.prototype._setHiddenValues = function($form) {
       $form.find("input#state").val(this.my.zid);
-      return $form.find("input#origin").val(this._encodeURL(this.options.referrerUrl || this.my.currentUrl));
+      return $form.find("input#origin").val(this._encodeURL(this.getReferrerUrl()));
     };
 
     Login.prototype._determineClient = function() {

--- a/dist/login.js
+++ b/dist/login.js
@@ -12,7 +12,8 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
     DEFAULT_OPTIONS = {
       prefillEmailInput: true,
       showDialogEventTemplate: 'uiShow{type}Dialog',
-      redirectOnLogin: true
+      redirectOnLogin: true,
+      referrerUrl: null
     };
 
     function Login(options) {
@@ -115,8 +116,9 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
     };
 
     Login.prototype.wireupSocialLinks = function($div) {
-      var baseUrl, fbLink, googleLink, twitterLink;
-      baseUrl = zutron_host + "?zid_id=" + this.my.zid + "&referrer=" + (encodeURIComponent(this.my.currentUrl));
+      var baseUrl, fbLink, googleLink, twitterLink, url;
+      url = this.options.referrerUrl || this.my.currentUrl;
+      baseUrl = zutron_host + "?zid_id=" + this.my.zid + "&referrer=" + (encodeURIComponent(url));
       if (this.options.realm) {
         baseUrl += "&realm=" + this.options.realm;
       }
@@ -215,6 +217,10 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
 
     Login.prototype.setRedirectOnLogin = function(value) {
       return this.options.redirectOnLogin = value;
+    };
+
+    Login.prototype.setReferrerUrl = function(url) {
+      return this.options.referrerUrl = url;
     };
 
     Login.prototype._enableLoginRegistration = function() {
@@ -566,7 +572,7 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
 
     Login.prototype._setHiddenValues = function($form) {
       $form.find("input#state").val(this.my.zid);
-      return $form.find("input#origin").val(this._encodeURL(window.location.href));
+      return $form.find("input#origin").val(this._encodeURL(this.options.referrerUrl || this.my.currentUrl));
     };
 
     Login.prototype._determineClient = function() {
@@ -645,6 +651,9 @@ define(['jquery', 'primedia_events', 'login/error_handler', 'jquery.cookie'], fu
     },
     setRedirectOnLogin: function(value) {
       return this.instance.setRedirectOnLogin(value);
+    },
+    setReferrerUrl: function(url) {
+      return this.instance.setReferrerUrl(url);
     }
   };
 });

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -27,6 +27,7 @@ define [
       prefillEmailInput: true
       showDialogEventTemplate: 'uiShow{type}Dialog'
       redirectOnLogin: true
+      referrerUrl: null
     }
 
     constructor: (options) ->
@@ -92,7 +93,8 @@ define [
         $.cookie cookie, "", options
 
     wireupSocialLinks: ($div) ->
-      baseUrl = "#{zutron_host}?zid_id=#{@my.zid}&referrer=#{encodeURIComponent(@my.currentUrl)}"
+      url = @options.referrerUrl || @my.currentUrl
+      baseUrl = "#{zutron_host}?zid_id=#{@my.zid}&referrer=#{encodeURIComponent(url)}"
       baseUrl += "&realm=#{@options.realm}" if @options.realm
       baseUrl += '&technique='
       fbLink = $div.find("a.icon_facebook48")
@@ -148,6 +150,9 @@ define [
 
     setRedirectOnLogin: (value) ->
       @options.redirectOnLogin = value
+
+    setReferrerUrl: (url) ->
+      @options.referrerUrl = url
 
     _enableLoginRegistration: =>
       $('#zutron_register_form form').submit (e) =>
@@ -365,7 +370,7 @@ define [
 
     _setHiddenValues: ($form) ->
       $form.find("input#state").val @my.zid
-      $form.find("input#origin").val @_encodeURL(window.location.href)
+      $form.find("input#origin").val @_encodeURL(@options.referrerUrl || @my.currentUrl)
 
     _determineClient: ->
       if @my.currentUrl.indexOf('client') > 0
@@ -404,3 +409,4 @@ define [
   expireCookie: -> @instance.expireCookie()
   session: -> @instance.my.session
   setRedirectOnLogin: (value) -> @instance.setRedirectOnLogin(value)
+  setReferrerUrl: (url) -> @instance.setReferrerUrl(url)

--- a/src/login.coffee
+++ b/src/login.coffee
@@ -93,8 +93,7 @@ define [
         $.cookie cookie, "", options
 
     wireupSocialLinks: ($div) ->
-      url = @options.referrerUrl || @my.currentUrl
-      baseUrl = "#{zutron_host}?zid_id=#{@my.zid}&referrer=#{encodeURIComponent(url)}"
+      baseUrl = "#{zutron_host}?zid_id=#{@my.zid}&referrer=#{encodeURIComponent(@getReferrerUrl())}"
       baseUrl += "&realm=#{@options.realm}" if @options.realm
       baseUrl += '&technique='
       fbLink = $div.find("a.icon_facebook48")
@@ -153,6 +152,9 @@ define [
 
     setReferrerUrl: (url) ->
       @options.referrerUrl = url
+
+    getReferrerUrl: ->
+      @options.referrerUrl || @my.currentUrl
 
     _enableLoginRegistration: =>
       $('#zutron_register_form form').submit (e) =>
@@ -370,7 +372,7 @@ define [
 
     _setHiddenValues: ($form) ->
       $form.find("input#state").val @my.zid
-      $form.find("input#origin").val @_encodeURL(@options.referrerUrl || @my.currentUrl)
+      $form.find("input#origin").val @_encodeURL(@getReferrerUrl())
 
     _determineClient: ->
       if @my.currentUrl.indexOf('client') > 0


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1054856/stories/120028041

When logging in via AG.js, the login modal is shown via redirect to this URL:

`www.qa.apartmentguide.com/?show_login_modal=1&redirect_url=/map?...`

When logging in via user/pass, the `redirect_url` parameter is used directly.  However, social logins redirect elsewhere and then redirect back to the standard AG `/login/` route.  This PR allows the `origin` parameter (via `referrer`) to be overridden.
